### PR TITLE
Pass options to `prepend-http`

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,12 @@
 const url = require('url');
 const prependHttp = require('prepend-http');
 
-module.exports = x => {
+module.exports = (x, opts) => {
 	if (typeof x !== 'string') {
 		throw new TypeError(`Expected \`url\` to be of type \`string\`, got \`${typeof x}\` instead.`);
 	}
 
-	const withProtocol = prependHttp(x);
+	const withProtocol = prependHttp(x, opts);
 	const parsed = url.parse(withProtocol);
 
 	if (withProtocol !== x) {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ipv6"
   ],
   "dependencies": {
-    "prepend-http": "^1.0.1"
+    "prepend-http": "^2.0.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/readme.md
+++ b/readme.md
@@ -94,6 +94,29 @@ url.parse('[2001:db8::]:8000');
 */
 ```
 
+With passing options to [`prepend-http`](https://github.com/sindresorhus/prepend-http#options):
+
+```js
+var urlParseLax = require('url-parse-lax');
+
+urlParseLax('sindresorhus.com', {https: true});
+/*
+{
+	protocol: null,
+	slashes: true,
+	auth: null,
+	host: 'sindresorhus.com',
+	port: null,
+	hostname: 'sindresorhus.com',
+	hash: null,
+	search: null,
+	query: null,
+	pathname: '/',
+	path: '/',
+	href: 'https://sindresorhus.com/'
+}
+*/
+```
 
 ## API
 

--- a/readme.md
+++ b/readme.md
@@ -94,39 +94,21 @@ url.parse('[2001:db8::]:8000');
 */
 ```
 
-With passing options to [`prepend-http`](https://github.com/sindresorhus/prepend-http#options):
-
-```js
-var urlParseLax = require('url-parse-lax');
-
-urlParseLax('sindresorhus.com', {https: true});
-/*
-{
-	protocol: null,
-	slashes: true,
-	auth: null,
-	host: 'sindresorhus.com',
-	port: null,
-	hostname: 'sindresorhus.com',
-	hash: null,
-	search: null,
-	query: null,
-	pathname: '/',
-	path: '/',
-	href: 'https://sindresorhus.com/'
-}
-*/
-```
-
 ## API
 
-### urlParseLax(url)
+### urlParseLax(url, [options])
 
 #### url
 
 Type: `string`
 
 URL to parse.
+
+#### options
+
+Type: `Object`
+
+See options passed to [prepend-http](https://github.com/sindresorhus/prepend-http#options).
 
 
 ## Related

--- a/test.js
+++ b/test.js
@@ -9,4 +9,5 @@ test('parse urls', t => {
 	t.is(m('sindresorhus.com').hostname, 'sindresorhus.com');
 	t.is(m('192.168.0.1:80').hostname, '192.168.0.1');
 	t.is(m('[2001:db8::]:80').hostname, '2001:db8::');
+	t.true(m('sindresorhus.com', {https: true}).href.startsWith('https://'));
 });


### PR DESCRIPTION
Allows passing options to `prepend-http` to allow the HTTPS protocol to be set by default.